### PR TITLE
複数箇所で使用しているメンバー変数(プロパティ)取得メソッドを1箇所にまとめる

### DIFF
--- a/webapp/src/main/java/example/application/coordinator/employee/EmployeeRecordCoordinator.java
+++ b/webapp/src/main/java/example/application/coordinator/employee/EmployeeRecordCoordinator.java
@@ -34,8 +34,9 @@ public class EmployeeRecordCoordinator {
      * 従業員個人情報更新
      */
     public void update(Employee employee) {
-        employeeRecordService.registerName(employee.employeeNumber(), employee.name());
-        employeeRecordService.registerMailAddress(employee.employeeNumber(), employee.mailAddress());
-        employeeRecordService.registerPhoneNumber(employee.employeeNumber(), employee.phoneNumber());
+    	EmployeeNumber employeeNumber = employee.employeeNumber();
+        employeeRecordService.registerName(employeeNumber, employee.name());
+        employeeRecordService.registerMailAddress(employeeNumber, employee.mailAddress());
+        employeeRecordService.registerPhoneNumber(employeeNumber, employee.phoneNumber());
     }
 }


### PR DESCRIPTION
`example.application.coordinator.employee.EmployeeRecordCoordinator.register(Profile)`では、`employeeNumber`を定義して1箇所で代入しているので、`example.application.coordinator.employee.EmployeeRecordCoordinator.update(Employee)`でも同様にした方がよいと考えました。